### PR TITLE
cli: retry for other errno numbers

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,10 @@
 include COPYING
 include Makefile
 include requirements.txt
+include unittests.sh
 include man/resalloc-server.1
 recursive-include resalloc *.py
 recursive-include shelltests *.sh testrunner testlib
+recursive-include tests *.py
 recursive-include test-tooling resalloc* wrap
 recursive-include build_manpages/build_manpages *.py

--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,14 @@ shelltests:
 	done ; \
 	$$status
 
-check: shelltests
+.PHONY: unittests
+unittests:
+	status=true ; \
+	for python in $(TEST_PYTHONS); do \
+	    PYTHON=$$python ./unittests.sh || status=false ; \
+	done ;\
+	$$status
+
+check:
+	@$(MAKE) unittests
+	@$(MAKE) shelltests

--- a/buildrequirements.txt
+++ b/buildrequirements.txt
@@ -1,1 +1,3 @@
 psycopg2
+pytest
+pytest-cov

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -37,9 +37,11 @@ $(spec):
 	if test "$$version" != "$$tbversion" ; then \
 	    replace=$$tbversion ; \
 	fi; \
+	rm -f $(spec); \
 	sed -e "s/@VERSION@/$$version/" \
 	    -e "s/@TARBALL_VERSION@/$$replace/" \
-	    $(spec).tpl > $(spec)
+	    $(spec).tpl > $(spec) ; \
+	chmod -w $(spec)
 
 $(tarball): clean
 	$(generate_tarball)

--- a/rpm/resalloc.spec.tpl
+++ b/rpm/resalloc.spec.tpl
@@ -40,6 +40,8 @@ BuildRequires: postgresql-server
 BuildRequires: python3-alembic
 BuildRequires: python3-devel
 BuildRequires: python3-psycopg2
+BuildRequires: python3-pytest
+BuildRequires: python3-pytest-cov
 BuildRequires: python3-setuptools
 BuildRequires: python3-six
 BuildRequires: python3-sqlalchemy
@@ -50,6 +52,9 @@ BuildRequires: python3-yaml
 BuildRequires: python-alembic
 BuildRequires: python2-devel
 BuildRequires: python-psycopg2
+BuildRequires: python2-mock
+BuildRequires: python2-pytest
+BuildRequires: python2-pytest-cov
 BuildRequires: python2-setuptools
 BuildRequires: python2-six
 BuildRequires: python-sqlalchemy

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     license='GPLv2+',
     url='https://github.com/praiskup/resalloc',
     platforms=['any'],
-    packages=find_packages(),
+    packages=find_packages(exclude=('tests',)),
     data_files=[
         ('/etc/resallocserver', ['config/pools.yaml', 'config/server.yaml']),
     ],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+import six
+
+if six.PY3:
+    from unittest import mock
+    from unittest.mock import MagicMock
+else:
+    import mock
+    from mock import MagicMock

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,28 @@
+""" test for resalloc.client """
+
+import pytest
+
+from resalloc.client import Connection
+from tests import mock
+
+@mock.patch("resalloc.client.time.sleep")
+def test_errno_reconnect(p_sleep):
+    """ Test that "request_survives_server_restart" tries to reconnect. """
+    conn = Connection(
+        "http://localhost:654245",
+        request_survives_server_restart=True)
+
+    class _side_effect:
+        def __init__(self, conn):
+            self.conn = conn
+            self.called = 0
+        def __call__(self, _sleep_time):
+            print("called")
+            if self.called > 0:
+                conn._connection.survive_server_restart = False
+            self.called += 1
+
+    p_sleep.side_effect = _side_effect(conn)
+    with pytest.raises(Exception):
+        ticket = conn.newTicket(tags=["test"])
+    assert p_sleep.call_args_list == [mock.call(3), mock.call(3)]

--- a/unittests.sh
+++ b/unittests.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+script=$(readlink -f "$0")
+testdir=$(dirname "$script")/tests
+sourcedir=$(readlink -f "$testdir/..")
+
+: "${PYTHON=/usr/bin/python3}"
+
+if test -n "$PYTHONPATH"; then
+    PYTHONPATH=$PYTHONPATH:$sourcedir
+else
+    PYTHONPATH=$sourcedir
+fi
+export PYTHONPATH
+
+debug() { echo >&2 " * $*" ; }
+
+debug "sourcedir:  $sourcedir"
+debug "testdir:    $testdir"
+debug "PYTHON:     $PYTHON"
+debug "PYTHONPATH: $PYTHONPATH"
+
+exec "$PYTHON" -B -m pytest --cov-report term-missing --cov "$sourcedir" "$testdir" "$@"


### PR DESCRIPTION
And while I'm on it, let's fix python2 problems and catch 'sock.error'
which works both on python2 and python3.  Add unittest for this code.