### PR TITLE
server: better checker thread logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SHELLTEST_OPTIONS :=
 
 SHELL_TESTS := \
 	basic.sh \
+	check.sh \
 	reuse.sh
 
 TEST_PYTHONS   := python2 python3

--- a/config/pools.yaml
+++ b/config/pools.yaml
@@ -24,7 +24,12 @@
 ##      cmd_new: "/bin/allocate-vm"
 ##
 ##      # This command is run to check that the VM is up.  If the command succeeds,
-##      # resource is considered to be working.
+##      # resource is considered to be working.  We run this checker
+##      # periodically against all "UP" resources, no matter if the resources
+##      # has assigned ticket.  Among other environment variables, the script has
+##      # also the RESALLOC_RESOURCE_DATA env variable available which contains
+##      # base64 encoded value of the stdout output from `cmd_new` (for virtual
+##      # machines, it e.g. usually contains the IP address in some form).
 ##      cmd_livecheck: "/bin/check-vm"
 ##
 ##      # The minimum delay between two livechecks is 300s (not more often).

--- a/pylintrc
+++ b/pylintrc
@@ -9,6 +9,11 @@ init-hook=
     gitrootdir = subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode("utf-8").strip()
     sys.path.insert(0, os.path.join(gitrootdir))
 
+# Reasoning for class ignore
+# --------------------------
+# RState, TState
+#     Pylint doesn't parse the meta-class to detect the attributes.
+ignored-classes=RState,TState
 
 [MESSAGES CONTROL]
 # Reasoning for wide warning ignore

--- a/resallocserver/config.py
+++ b/resallocserver/config.py
@@ -30,6 +30,9 @@ CONFIG = {
     'host': 'localhost',
     'port': 49100,
     'loglevel': 'info',
+    # Maximum number of seconds Manager threads wait in loop.  Used for tests
+    # only ATM.  Watcher sleeps sleeptime/2.
+    'sleeptime': 20,
 }
 
 CONFIG_DIR = config_dir

--- a/resallocserver/logic.py
+++ b/resallocserver/logic.py
@@ -72,6 +72,7 @@ class QResources(QObject):
         re-used first.
         """
         return (self.up().filter(models.Resource.ticket_id.is_(None))
+                         .filter(models.Resource.check_failed_count==0)
                          .order_by(models.Resource.sandbox.is_(None)))
 
     def taken(self):
@@ -104,6 +105,17 @@ class QResources(QObject):
             .filter(models.Resource.ticket_id.is_(None))
             # was this actually ever used?
             .filter(models.Resource.released_at.isnot(None))
+        )
+
+    def check_failure_candidates(self):
+        """
+        List of resources that are UP, and have non-zero check_failed_count.
+        """
+        return (
+            self.up()
+            # isn't it still used?
+            .filter(models.Resource.ticket_id.is_(None))
+            .filter(models.Resource.check_failed_count > 0)
         )
 
     def clean(self):

--- a/shelltests/tests/check.sh
+++ b/shelltests/tests/check.sh
@@ -1,0 +1,129 @@
+#! /bin/bash
+
+# Shell tests runner.
+# Copyright (C) 2020 Red Hat, Inc.
+#
+# This file is part of resalloc project.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+PREALLOC=5
+MAX=15
+DBNAME=resalloc-test
+: "${DATABASE=sqlite}"
+
+. ./testlib
+
+cd "$WORKDIR" || exit 1
+
+debug "I'm in $PWD"
+cleanup_actions=()
+cleanup ()
+{
+    debug "cleanup"
+    set +e
+    for action in "${cleanup_actions[@]}"
+    do
+        eval "$action"
+    done
+}
+trap cleanup EXIT
+
+check_cmd="\
+ echo decoded.. ; \
+ echo \"\$RESALLOC_RESOURCE_DATA\" | base64 --decode ; \
+ echo not_decoded..; \
+ /usr/bin/env | grep ^RESALLOC_RESOURCE_DATA; \
+ exit 1"
+
+mkdir etc
+cat > etc/pools.yaml <<EOF
+basic:
+    max: $MAX
+    max_prealloc: $PREALLOC
+    cmd_new: "echo >&2 before; env | grep ^RESALLOC_; echo >&2 after"
+    cmd_delete: "echo >&2 stderr; echo stdout"
+    cmd_livecheck: '$check_cmd'
+    livecheck_period: 1
+    tags:
+        - A
+        - B
+EOF
+
+uname=$(id -u -n)
+dburl="sqlite:///$WORKDIR/server-sql"
+case $DATABASE in
+    sqlite) ;;
+    postgresql)
+        port=${POSTGRESQL_PORT-65432}
+        host=/tmp
+        datadir=$WORKDIR/pgdata
+        info "preparing PostgreSQL server"
+        postgresql_start "$port" "$datadir" "$host" &>/dev/null
+        createdb -p "$port" -h "$host" "$DBNAME"
+        cleanup_actions+=( "pg_ctl stop -D \"$datadir\" -m i >/dev/null" )
+        dburl="postgresql://$uname@/$DBNAME?host=$host&port=$port"
+        ;;
+    *) false ;;
+esac
+
+cat > etc/server.yaml <<EOF
+db_url: "$dburl"
+logdir: $WORKDIR
+port: $SERVER_PORT
+loglevel: debug
+sleeptime: 1
+EOF
+
+export CONFIG_DIR=$WORKDIR/etc
+
+server &>/dev/null
+cleanup_actions+=( "shutdown_server $server_pid" )
+
+# Wait for the server to start up.
+counter=30
+while ! maint resource-list &>/dev/null; do
+    counter=$(( counter - 1 ))
+    test $counter -gt 0
+done
+
+info "Wait for $PREALLOC preallocated machines"
+counter=30
+while true; do
+    up=$(maint resource-list --up | wc -l)
+    counter=$(( counter - 1))
+    if test "$up" -eq "$PREALLOC"; then
+        break
+    fi
+    test "$up" -lt "$PREALLOC" || {
+        maint resource-list --up
+        error "too much resources"
+    }
+    test $counter -gt 0
+    sleep 1
+done
+
+info "wait till the first set of VMs is deleted by watcher"
+while ! test -f "$WORKDIR/hooks/"*006_watch; do
+    sleep 1
+done
+
+output=$(sort "$WORKDIR/hooks/"*005_watch | uniq)
+case $output in
+    *RESALLOC_ID=5*) ;;
+    *) fail "missing RESALLOC_ID in $output" ;;
+esac
+
+# vi: ft=sh

--- a/shelltests/tests/reuse.sh
+++ b/shelltests/tests/reuse.sh
@@ -56,7 +56,7 @@ cat > etc/pools.yaml <<EOF
 reuse:
     max: $NORMAL_MAX
     max_prealloc: $NORMAL_PREALLOC
-    cmd_new: "echo >&2 before; env | grep RESALLOC_; echo >&2 after"
+    cmd_new: "echo >&2 before; env | grep ^RESALLOC_; echo >&2 after"
     cmd_delete: "echo >&2 stderr; echo stdout"
     cmd_livecheck: "echo >&2 stderr; echo stdout"
     livecheck_period: 1
@@ -69,7 +69,7 @@ reuse:
 reuse_count:
     max: $COUNT_MAX
     max_prealloc: $COUNT_PREALLOC
-    cmd_new: "echo >&2 before; env | grep RESALLOC_; echo >&2 after"
+    cmd_new: "echo >&2 before; env | grep ^RESALLOC_; echo >&2 after"
     cmd_delete: "echo >&2 stderr; echo stdout"
     cmd_livecheck: "echo >&2 stderr; echo stdout"
     livecheck_period: 1
@@ -82,7 +82,7 @@ reuse_count:
 reuse_time:
     max: $TIME_MAX
     max_prealloc: $TIME_PREALLOC
-    cmd_new: "echo >&2 before; env | grep RESALLOC_; echo >&2 after"
+    cmd_new: "echo >&2 before; env | grep ^RESALLOC_; echo >&2 after"
     cmd_delete: "echo >&2 stderr; echo stdout"
     cmd_livecheck: "echo >&2 stderr; echo stdout"
     livecheck_period: 1


### PR DESCRIPTION
(a) Provide RESALLOC_RESOURCE_DATA env var to checker.  This is useful
when e.g. checking for working AWS VMs -- to not re-translate the VM
name to PublicIP all the time (when the IP is in data).  This saves a
lot of API calls quota.

(b) Stop removing resources directly by Watcher thread, and let this
on Manager and garbage collector.  This simplifies code, and there's one
more race between Manager and Watcher.

(c) Never assign resources which nave non-zero Watcher fail counter.

(d) Document the RESALLOC_RESOURCE_DATA variable.