### PR TITLE
Backward compat for "host" config option

### DIFF
--- a/bin/resalloc-server
+++ b/bin/resalloc-server
@@ -91,7 +91,10 @@ class Server(threading.Thread):
     server = None
 
     def run(self):
-        self.server = CLSXMLRPC((CONFIG['hostname'], CONFIG['port']))
+        # use CONFIG["hostname"], or CONFIG["host"], or fallback to "localhost"
+        hostname = CONFIG.get("host", "localhost")
+        hostname = CONFIG.get("hostname", hostname)
+        self.server = CLSXMLRPC((hostname, CONFIG['port']))
         self.server.allow_none = True
         self.server.daemon_threads = True
         self.server.register_introspection_functions()


### PR DESCRIPTION
One of the systems running resalloc-server is actually running a
pre-release versions..., and it suddenly stopped accepting connections
after the "host" => "hostname" switch.  Turns out it's probably better
to accept the "host" variant too, to not cause accidental headaches.

Complements 78262fa9d8e5d744ee8aa742102e0be1845807e6