### PR TITLE
server: drop sqlite_where partial index

### DIFF
--- a/resallocserver/alembic/versions/210774551cd3_performance_indexes.py
+++ b/resallocserver/alembic/versions/210774551cd3_performance_indexes.py
@@ -25,8 +25,7 @@ def upgrade():
         batch_op.create_index(batch_op.f('ix_resources_pool'), ['pool'], unique=False)
         batch_op.create_index(batch_op.f('ix_resources_state'), ['state'], unique=False)
         batch_op.create_index('ix_not_ended_resources', ['state'], unique=False,
-                              postgresql_where=sa.text("state != 'ENDED'"),
-                              sqlite_where=sa.text("state != 'ENDED'"))
+                              postgresql_where=sa.text("state != 'ENDED'"))
 
     with op.batch_alter_table('ticket_tags', schema=None) as batch_op:
         batch_op.create_index(batch_op.f('ix_ticket_tags_ticket_id'), ['ticket_id'], unique=False)

--- a/resallocserver/models.py
+++ b/resallocserver/models.py
@@ -63,8 +63,7 @@ class Resource(Base, TagMixin):
 
     __table_args__ = (
         Index('ix_not_ended_resources', state,
-              postgresql_where=(state != 'ENDED'),
-              sqlite_where=(state!= 'ENDED')),
+              postgresql_where=(state != 'ENDED')),
     )
 
 


### PR DESCRIPTION
This sqlite_where is not supported by sqlalchemy 0.9.8 currently on EL7.
We should ideally port everything to python36 on EL7, but that is too
much work.  So for now, keep postgresql-only partial index, as those who
run against SQLite probably don't have that huge datasets anyway.