### PR TITLE
Avoid over-allocating on max_prealloc quota

### DIFF
--- a/resallocserver/logic.py
+++ b/resallocserver/logic.py
@@ -105,11 +105,18 @@ class QResources(QObject):
         items = {}
         items['on']     = self.on().all()
         items['up']     = [x for x in items['on'] if x.state  == RState.UP]
+        # Resources that can be assigned.
         items['ready']  = [x for x in items['up'] if x.ticket_id is None]
+        # Opposite for "ready".
         items['taken']  = [x for x in items['up'] if x.ticket_id is not None]
         items['start']  = [x for x in items['on'] if x.state  == RState.STARTING]
         items['term']   = [x for x in items['on'] if x.state  == RState.DELETING]
-        items['released'] = [x for x in items['up'] if x.releases_counter > 0]
+        # Ready, but already released resources that can only be assigned to
+        # ticket from the same sandbox as before.
+        items['released'] = [x for x in items['ready'] if x.releases_counter > 0]
+        # Ready resources that have not been assigned to any ticket/sandbox yet.
+        items['free'] = [x for x in items['ready'] if x.releases_counter <= 0]
+        items['releasing'] = [x for x in items['on'] if x.state == RState.RELEASING]
         return {key: len(value) for (key, value) in items.items()}
 
     def clean_candidates(self):

--- a/resallocserver/manager.py
+++ b/resallocserver/manager.py
@@ -478,7 +478,7 @@ class Pool(object):
             log.debug(msg)
 
             if stats['on'] >= self.max \
-                   or stats['ready'] + stats['start'] - stats['released'] >= self.max_prealloc \
+                   or stats['free'] + stats['start'] >= self.max_prealloc \
                    or stats['start'] >= self.max_starting \
                    or self._too_soon():
                 # Quota reached, don't allocate more.


### PR DESCRIPTION
The stats[released] number was wrongly calculated from stats[on],
instead of from stats[ready].

Every re-"taken" resource was part of "released" resource set,
and thus it was be part of max_prealloc calculation:

    "stats['ready'] + stats['start'] - stats['released']"

Every re-taken resource caused one resource allocation over the
max_prealloc limit.