### PR TITLE
maint: fix traceback on starting instances

### DIFF
--- a/resallocserver/maint.py
+++ b/resallocserver/maint.py
@@ -84,10 +84,13 @@ class Maintainer(object):
             resources = QResources(session)
             for resource in resources.on().all():
                 try:
+                    utf_data = "<None>"
+                    if resource.data:
+                        utf_data = resource.data.decode("utf8")
                     command = args.command.format(
                         name=resource.name,
                         state=resource.state,
-                        data_utf8=resource.data.decode("utf8"),
+                        data_utf8=utf_data,
                     )
                 except KeyError as err:
                     sys.stderr.write(str(err))


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/bin/resalloc-maint", line 83, in <module>
    sys.exit(main())
  File "/usr/bin/resalloc-maint", line 76, in main
    maint.foreach_resource(args)
  File "/usr/lib/python3.9/site-packages/resallocserver/maint.py", line 90, in foreach_resource
    data_utf8=resource.data.decode("utf8"),
AttributeError: 'NoneType' object has no attribute 'decode'