### PR TITLE
Add command for printing logs

### DIFF
--- a/bin/resalloc-maint
+++ b/bin/resalloc-maint
@@ -41,6 +41,14 @@ parser_resource_delete.add_argument(
         help="The resource IDs",
         nargs='+')
 
+parser_resource_logs = subparsers.add_parser(
+    "resource-logs",
+    help="Print and follow logs for a resource")
+parser_resource_logs.add_argument(
+        "resource",
+        help="The resource IDs",
+        nargs='+')
+
 p_t_list = subparsers.add_parser(
         "ticket-list",
         help="List not-yet-closed tickets")
@@ -68,6 +76,9 @@ def main():
 
         elif 'resource-delete' in args.subparser:
             maint.resource_delete(args.resource)
+
+        elif 'resource-logs' in args.subparser:
+            maint.resource_logs(args.resource)
 
         elif 'ticket-list' in args.subparser:
             maint.ticket_list()

--- a/resallocserver/maint.py
+++ b/resallocserver/maint.py
@@ -15,6 +15,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+import os
 import subprocess
 import sys
 
@@ -58,6 +59,19 @@ class Maintainer(object):
             with session_scope() as session:
                 resources = QResources(session=session)
                 resources.kill(res_id)
+
+    def resource_logs(self, resources=None):
+        hooks_dir = os.path.join(app.config["logdir"], "hooks")
+        paths = []
+        for resource in resources:
+            # We can't wildcard everything because then `tail' wouldn't
+            # discover newly created log files
+            suffixes = ["_alloc", "_watch", "_terminate"]
+            path = os.path.join(hooks_dir, resource.zfill(6))
+            paths.extend([path + suffix for suffix in suffixes])
+
+        cmd = ["tail", "-F", "-n+0"] + paths
+        subprocess.call(cmd)
 
     def ticket_list(self):
         with session_scope() as session:


### PR DESCRIPTION
Fix #74 

It allows to `tail -f` logs for a given resource, e.g.

    resalloc-maint resource-logs 123
