### PR TITLE
Fix resoure-info traceback for STARTING resources

### DIFF
--- a/resallocserver/models.py
+++ b/resallocserver/models.py
@@ -100,7 +100,10 @@ class Resource(Base, TagMixin, Serializer):
 
     def to_dict(self):
         result = super().to_dict()
-        result["data"] = result["data"].decode("utf8").strip()
+        # Decode resource data for better readability
+        # Some resoures doesn't have any data, e.g. STARTING ones
+        if result["data"]:
+            result["data"] = result["data"].decode("utf8").strip()
         return result
 
 


### PR DESCRIPTION
The STARTING resources doesn't have any data:

    Traceback (most recent call last):
    File "/usr/bin/resalloc-maint", line 114, in <module>
        sys.exit(main())
    File "/usr/bin/resalloc-maint", line 95, in main
        maint.resource_info(args.resource)
    File "/usr/lib/python3.10/site-packages/resallocserver/maint.py", line 64, in resource_info
        print(json.dumps(resource.to_dict(), indent=4))
    File "/usr/lib/python3.10/site-packages/resallocserver/models.py", line 103, in to_dict
        result["data"] = result["data"].decode("utf8").strip()
    AttributeError: 'NoneType' object has no attribute 'decode'