### PR TITLE
More intransigent control for failed resources

### DIFF
--- a/resallocserver/logic.py
+++ b/resallocserver/logic.py
@@ -138,6 +138,16 @@ class QResources(QObject):
             .filter(models.Resource.check_failed_count > 0)
         )
 
+    def check_failure_candidates_with_ticket(self):
+        """
+        List of resources that are UP, and have non-zero check_failed_count.
+        """
+        return (
+            self.up()
+            # isn't it still used?
+            .filter(models.Resource.check_failed_count > 10)
+        )
+
     def clean(self):
         return self.on().filter_by(state=RState.DELETE_REQUEST)
 


### PR DESCRIPTION
Fixes: https://pagure.io/copr/copr/issue/2083

Sometimes it happens that even though the resource has check_failed_count set to a number greater than 3, it is not deleted because it still has a ticket. This leads to endless jobs. We can be more intransigent and remove the resource after 10 checks, even though it still has a ticket.