### PR TITLE
A couple of WebUI deployment fixes

### DIFF
--- a/rpm/resalloc.spec.tpl
+++ b/rpm/resalloc.spec.tpl
@@ -170,7 +170,7 @@ cp -r %{name}webui/templates %buildroot%_datadir/%{name}webui/
 cp -r %{name}webui/static %buildroot%_datadir/%{name}webui/
 
 install -d -m 755 %buildroot%_var/www/
-cp -r %{name}webui/cgi-resalloc %buildroot%_var/www/cgi-%{name}
+install -p -m 755 %{name}webui/cgi-resalloc %buildroot%_var/www/cgi-%{name}
 %endif
 
 mkdir -p %buildroot%_unitdir

--- a/rpm/resalloc.spec.tpl
+++ b/rpm/resalloc.spec.tpl
@@ -114,6 +114,7 @@ Summary:    %sum - webui part
 Requires:   %default_python-%srcname = %version-%release
 Requires: %name-server
 Requires: python3-flask
+Recommends: %name-selinux
 %endif
 
 %description webui
@@ -145,6 +146,22 @@ Summary: %sum - Python 2 client library
 The python2-%name package provides Python 2 client library for talking
 to the resalloc server.
 %endif
+
+
+%package selinux
+Summary: SELinux module for %{name}
+Requires: %name-webui = %version-%release
+# Requires(post): policycoreutils-python
+BuildRequires: selinux-policy-devel
+%{?selinux_requires}
+
+%description selinux
+%desc
+
+%post selinux
+semanage fcontext -a -t httpd_sys_script_exec_t \
+    %_var/www/cgi-%{name} 2>/dev/null || :
+restorecon -R %_var/www/cgi-%{name} || :
 
 
 %prep
@@ -270,6 +287,9 @@ useradd -r -g "$group" -G "$group" -s /bin/bash \
 %_datadir/%{name}webui/
 %_var/www/cgi-%{name}
 %endif
+
+%files selinux
+
 
 %changelog
 * Fri Aug 02 2019 Pavel Raiskup <praiskup@redhat.com> - 2.6-1


### PR DESCRIPTION
Adding an executable permissions and `httpd_sys_script_exec_t` context to the CGI script.
(I originally did that in ansible but that causes problems when reinstalling the package, and also would require extra configuration for different resalloc instances. The smart move is to do it in the package spec file)