### PR TITLE
maint: fix resource-info for non-existing resource

### DIFF
--- a/resallocserver/maint.py
+++ b/resallocserver/maint.py
@@ -60,8 +60,13 @@ class Maintainer(object):
                 query = query.filter(Resource.id == resource)
             else:
                 query = query.filter(Resource.name == resource)
-            resource = query.one()
-            print(json.dumps(resource.to_dict(), indent=4))
+
+            resource_obj = query.one_or_none()
+            if not resource_obj:
+                log.error("Unknown resource: {0}".format(resource))
+                return
+
+            print(json.dumps(resource_obj.to_dict(), indent=4))
 
     def resource_delete(self, args):
         resources = args.resource


### PR DESCRIPTION
To prevent tracebacks like this:

```
[resalloc@copr-be-dev ~][STG]$ resalloc-maint resource-info 113594
Traceback (most recent call last):
  File "/usr/bin/resalloc-maint", line 114, in <module>
    sys.exit(main())
  File "/usr/bin/resalloc-maint", line 95, in main
    maint.resource_info(args.resource)
  File "/usr/lib/python3.10/site-packages/resallocserver/maint.py", line 64, in resource_info
    print(json.dumps(resource.to_dict(), indent=4))
  File "/usr/lib64/python3.10/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/lib64/python3.10/json/encoder.py", line 201, in encode
    chunks = list(chunks)
  File "/usr/lib64/python3.10/json/encoder.py", line 431, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/usr/lib64/python3.10/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/usr/lib64/python3.10/json/encoder.py", line 438, in _iterencode
    o = _default(o)
  File "/usr/lib64/python3.10/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type bytes is not JSON serializable
```