### PR TITLE
clean-unknown-workers: don't clean STARTING resources, etc.

### DIFF
--- a/resallocserver/manager.py
+++ b/resallocserver/manager.py
@@ -357,7 +357,7 @@ class CleanUnknownWorker(Worker):
 
     def _list_known_resources(self):
         with session_scope() as session:
-            on = QResources(session).up().all()
+            on = QResources(session).on().all()
             return [resource.name for resource in on]
 
 


### PR DESCRIPTION
Any resource with the "on()" state is considered to be "known" by resalloc, and shouldn't be removed by CleanUnknownWorker.