### PR TITLE
webui: fix traceback from the pools page

### DIFF
--- a/resallocwebui/app.py
+++ b/resallocwebui/app.py
@@ -38,7 +38,7 @@ def pools():
     result = {}
 
     # Read configuration from pools.yaml
-    pools_config = reload_config()
+    _, pools_config = reload_config()
 
     # Prepare the two-dimensional array, and fill it with zeros
     for name, pool in pools_config.items():


### PR DESCRIPTION
Fix https://github.com/fedora-copr/copr/issues/2882

Since we have on-demand resources, the `reload_config` now returns a tuple. See how it is used in `resallocserver.manager`.