### PR TITLE
rpm: don't require webui by selinux

### DIFF
--- a/rpm/resalloc.spec.tpl
+++ b/rpm/resalloc.spec.tpl
@@ -152,7 +152,6 @@ to the resalloc server.
 
 %package selinux
 Summary: SELinux module for %{name}
-Requires: %name-webui = %version-%release
 # Requires(post): policycoreutils-python
 BuildRequires: selinux-policy-devel
 %{?selinux_requires}


### PR DESCRIPTION
While ATM the only package using resalloc-selinux is resalloc-webui, the reverse dependency doesn't make sense.  And in the future, the scope of the selinux module may increase.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2234812