### PR TITLE
manager: fix "unknown resources cleanup" traceback

### DIFF
--- a/resallocserver/manager.py
+++ b/resallocserver/manager.py
@@ -688,6 +688,11 @@ class Pool(object):
 
         with session_scope() as session:
             dbinfo = session.query(models.Pool).get(self.name)
+            if not dbinfo:
+                app.log.warning(
+                    "Can not perform cleanup in the configured "
+                    "pool %s: no such pool in SQL database.", self.name)
+                return
             last_cleanup = dbinfo.cleaning_unknown_resources
             if last_cleanup is None:
                 last_cleanup = datetime.min


### PR DESCRIPTION
When a new on-demand pool is configured in pools.yaml, the cleanup logic is typically executed before a new resource is started there, and thus also before the database entry is created.

Fixes: #128