### PR TITLE
resalloc-check-vm-ip: allow picking custom SSH username

### DIFF
--- a/bin/resalloc-check-vm-ip
+++ b/bin/resalloc-check-vm-ip
@@ -31,4 +31,4 @@ test -n "$RESALLOC_RESOURCE_DATA"
 # we only put IP out in spawning script, nothing else
 set -- $(echo "$RESALLOC_RESOURCE_DATA" | base64 --decode)
 IP=$1
-ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 "root@$IP" true
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 "${SSH_USER-root}@$IP" true


### PR DESCRIPTION
This is related to the OpenScanHub use-case.  They want to do the periodic SSH liveness probes, though since they do not need the `root` access onto workers, they do not make the `root` account available.