### PR TITLE
Fix FTBFS in Fedora Rawhide

### DIFF
--- a/resallocserver/logic.py
+++ b/resallocserver/logic.py
@@ -164,7 +164,7 @@ class QTickets(QObject):
             .filter_by(state=TState.OPEN)
         )
         if preload_tags:
-            query = query.options(joinedload("tags"))
+            query = query.options(joinedload(models.Ticket.tags))
         return query
 
 


### PR DESCRIPTION
Fix #141

    sqlalchemy.exc.ArgumentError: Strings are not accepted for attribute
    names in loader options; please use class-bound attributes directly.