### PR TITLE
agent-spawner: base64 encoding one more time

### DIFF
--- a/resalloc_agent_spawner/worker.py
+++ b/resalloc_agent_spawner/worker.py
@@ -2,8 +2,6 @@
 Handle certain tasks by a background daemon process.
 """
 
-import base64
-
 from copr_common.background_worker import BackgroundWorker
 
 from resalloc_agent_spawner.helpers import (
@@ -37,7 +35,9 @@ class AgentHandler(BackgroundWorker, CmdCallerMixin):
         # We know there's self._redis initialized by parent class so we don't
         # create yet another connection.
         redis_dict = self._redis.hgetall(redis_key)
-        ticket_data = base64.b64encode(redis_dict["data"])
+
+        # dispatcher already converted data to b64-encoded strings
+        ticket_data = redis_dict["data"]
 
         if redis_dict["state"] == "PREPARING":
             if self.cmd_take(redis_dict["group_id"], ticket_data):


### PR DESCRIPTION
The base64 encoding is worth doing on the dispatcher side, and store strings to Redis, instead of decoding and encoding it once more in worker (see #155).

Fixes: #155