### PR TITLE
agent-spawner: redirect output from shell hooks

### DIFF
--- a/resalloc_agent_spawner/helpers.py
+++ b/resalloc_agent_spawner/helpers.py
@@ -111,4 +111,6 @@ class CmdCallerMixin:
                 "AGENT_SPAWNER_RESOURCE_DATA": str(data),
             },
             "shell": True,
+            "stdout": subprocess.DEVNULL,
+            "stderr": subprocess.DEVNULL,
         }


### PR DESCRIPTION
There's otherwise a risk of receiving SIGPIPE or other termination signal only because we have no output file to write to.