### PR TITLE
Do not load server configuration by web-UI

### DIFF
--- a/resallocserver/alembic/versions/b50e3f64fc2d_track_pool_max_value.py
+++ b/resallocserver/alembic/versions/b50e3f64fc2d_track_pool_max_value.py
@@ -1,0 +1,17 @@
+"""
+Track Pool max value
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'b50e3f64fc2d'
+down_revision = '78237445aff8'
+
+def upgrade():
+    with op.batch_alter_table('pools', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('max', sa.Integer(), nullable=True))
+
+def downgrade():
+    with op.batch_alter_table('pools', schema=None) as batch_op:
+        batch_op.drop_column('max')

--- a/resallocserver/models.py
+++ b/resallocserver/models.py
@@ -40,6 +40,7 @@ class Pool(Base):
     name = Column(String, primary_key=True)
     last_start = Column(Float, default=0)
     cleaning_unknown_resources = Column(DateTime, server_default=func.now())
+    max = Column(Integer, default=0)
 
 
 class Ticket(Base, TagMixin):


### PR DESCRIPTION
The web-UI is typically driven by http server, without permissions to read /etc/resallocserver files or write /var/log/resallocserver.

Fixes: https://github.com/fedora-copr/copr/issues/3202