### PR TITLE
server: ignore exceptions in the Watcher loop

### DIFF
--- a/resallocserver/manager.py
+++ b/resallocserver/manager.py
@@ -453,7 +453,14 @@ class Watcher(threading.Thread):
 
     def run(self):
         while True:
-            self.loop()
+            try:
+                self.loop()
+            except:  # pylint: disable=bare-except
+                # We are a daemon thread that nobody restarts in case of
+                # unexpected failure, so let's try to recover :shrug:.  If the
+                # parent dies, we get killed without any announcement, sounds
+                # fair.
+                app.log.exception("Watcher's logic raised exception, ignoring.")
             time.sleep(app.config["sleeptime"] / 2)
 
 


### PR DESCRIPTION
This is a very poor hack, but we don't face exceptions too frequently here.  Let's restart if e.g. this happens:

Traceback (most recent call last):
  File "/usr/lib64/python3.12/site-packages/sqlalchemy/engine/base.py", line 1910, in _execute_context
    self.dialect.do_execute(
  File "/usr/lib64/python3.12/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
    cursor.execute(statement, parameters)
sqlite3.OperationalError: database is locked