### PR TITLE
server, webui: add pool descriptions

### DIFF
--- a/resallocserver/manager.py
+++ b/resallocserver/manager.py
@@ -465,6 +465,7 @@ class Watcher(threading.Thread):
 
 
 class Pool(object):
+    description = None
     max = 4
     max_starting = 1
     max_prealloc = 2

--- a/resallocwebui/templates/pools.html
+++ b/resallocwebui/templates/pools.html
@@ -12,6 +12,7 @@ Resalloc pools
     <thead class="thead-dark">
     <tr>
         <th scope="col">Pool</th>
+        <th scope="col">Description</th>
         <th scope="col">Max</th>
         <th scope="col">Up</th>
         <th scope="col">Ready</th>
@@ -25,6 +26,7 @@ Resalloc pools
     {% for pool, info in information.items()|sort(attribute='0') %}
     <tr>
         <th scope="row">{{ pool }}</th>
+        <td class="col-sm-4">{{ info['DESCRIPTION'] |default(omit, True) }}</td>
         <td>{{ info['MAX'] }}</td>
         <td>{{ info['UP'] }}</td>
         <td>{{ info['READY'] }}</td>


### PR DESCRIPTION
Fix #133

An example description for a builder:

    aws_x86_64_normalreserved_prod:
      description: >
        A pool of reserved x86_64 instances in the Amazon AWS Fedora organization.
        Thank you IBM for sponsoring these builders.