### PR TITLE
server: reduce alpha for our moving averages

### DIFF
--- a/resallocserver/manager.py
+++ b/resallocserver/manager.py
@@ -411,7 +411,7 @@ class AllocWorker(Worker):
         # Approximation is good enough here, so we are using the moving average.
         # The alpha should be between 0.1 and 0.9, the higher the value, the
         # better it reacts to sudden spikes in failures
-        alpha = 0.5
+        alpha = 0.2
 
         if success:
             if dbpool.startup_time_avg is None:


### PR DESCRIPTION
The 0.5 favors new values too strongly, making our Zabbix graphs too spiky.

The easiest example is on the success rate. Let's assume our current
EMA (Exponential Moving Average) is 100%, and then we get one failure. This is
how different alphas affect the EMA value.

    EMA = 100%, Next Value = 0%
    alpha = 0.1 -> 90%
    alpha = 0.2 -> 80%
    alpha = 0.3 -> 70%
    alpha = 0.5 -> 50%
    alpha = 0.8 -> 20%

That means that one failure immediately sends us under the warning
threshold (which is currently 60%). With alpha 0.2 it would take us 3 subsequent
failures and with 0.1 it would require 5 subsequent failures.

The situation is a bit more complicated with our startup times but assuming a
starting EMA is 60s and then we have one startup that takes 250s. The alphas
affect it this way:

Starting EMA: 60s, Next Value: 250s

    alpha = 0.1 -> 79s
    alpha = 0.2 -> 98s
    alpha = 0.3 -> 117s
    alpha = 0.5 -> 155s
    alpha = 0.8 -> 212s

So with alpha 0.2 it would take 6 consecutive slow attempts to hit our warning
threshold (currently 200s) and with alpha 0.1 it would take 13 attempts.

I think both alpha 0.2 or 0.1 are fine for us but 0.5 too much.

But we may need different alphas for different stats. Because for the success
rate even lower than 0.1 would be fine, while for the startup times the alpha
can be much higher since we are only counting successful starts.